### PR TITLE
Update error message format and sdk constraint to match.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.16]
+* Updated SDK constraint to support new error message formats
+* Updated error message formats
+
 ## [0.1.14] - TODO:修复了自定义键盘切换回原生键盘无法输入的问题
 * 修复了自定义键盘切换回原生键盘无法输入的问题
 * Popover可以设置遮罩层颜色

--- a/lib/keyboards/keyboard_manager.dart
+++ b/lib/keyboards/keyboard_manager.dart
@@ -99,7 +99,7 @@ class CoolKeyboard {
           exception: exception,
           stack: stack,
           library: 'services library',
-          context: 'during a platform message response callback',
+          context: ErrorDescription('during a platform message response callback'),
         ));
       }
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,12 @@
 name: cool_ui
 description: Some practical Widget for flutter,Popover,Weui,Custom Keyboard
-version: 0.1.15
+version: 0.1.16
 author: Kevin <liangkaikevin@gmail.com>
 homepage: https://github.com/Im-Kevin/cool_ui
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  flutter: ">=1.7.0 <2.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This change is needed due to a breaking change in the API for FlutterErrorDetails in Flutter 1.7.