### PR TITLE
跟系统键盘来回切换可能导致的问题

### DIFF
--- a/lib/keyboards/keyboard_manager.dart
+++ b/lib/keyboards/keyboard_manager.dart
@@ -219,7 +219,7 @@ class CoolKeyboard {
       //   }
       // });
       if (animation) {
-        _pageKey!.currentState!.exitKeyboard();
+        _pageKey!.currentState?.exitKeyboard();
         Future.delayed(Duration(milliseconds: 116)).then((_) {
           _root!.clearKeyboard();
         });


### PR DESCRIPTION
用例：两个输入框，一个系统键盘，一个自定义键盘。

打开自定义键盘，然后关闭。后打开系统键盘，在关闭时，偶尔发生错误。